### PR TITLE
MathJax: Disable preview, use SVG output

### DIFF
--- a/header_prenav.html
+++ b/header_prenav.html
@@ -30,6 +30,7 @@
   <!-- MathJax -->
   <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
+        "fast-preview": { disabled: true },
         TeX: 
             {
             Macros: 
@@ -49,7 +50,7 @@
         "HTML-CSS": {scale: 100}
         });
   </script>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_SVG"></script>
 
 </head>
 <body style="background-color:#FFF;">


### PR DESCRIPTION
Hi,

this commit disables the "fast preview" MathJax feature and switches from HTML-CSS to SVG output.

The former is not very useful: if there are few inline equations, rendering them is relatively fast, if there are many multi-line equations, the fast preview mode is unbelievable ugly and nearly completely useless; as such, it is necessary to wait for the full rendering anways.

The latter is motivated by much better rendering with SVG in equations with many indices (such as tensors), see the two pictures below:

With HTML-CSS:

![With HTML-CSS](https://user-images.githubusercontent.com/32578588/69542515-e54b2780-0f8b-11ea-853f-870cd5418b76.png)

With SVG:

![With SVG](https://user-images.githubusercontent.com/32578588/69542509-e2503700-0f8b-11ea-901f-63396c0c37b1.png)

Notice that the commas between `m_{j-1}` and `m_j` are nearly completely hidden in the HTML-CSS output but very visible in the SVG output. As a side effect, at least for me the SVG also renders much faster than the HTML-CSS.