### PR TITLE
Repaired a Reference

### DIFF
--- a/src/peps/index.bib
+++ b/src/peps/index.bib
@@ -1,10 +1,10 @@
-
 @article{Verstraete:2004p,
-	Author = {F. Verstraete and J. I. Cirac},
-	Title = {Renormalization algorithms for Quantum-Many Body Systems in two and higher dimensions},
-    eprint = {cond-mat/0407066},
-    URL = {https://arxiv.org/abs/cond-mat/0407066},
-	Year = {2004}}
+    title = {Renormalization algorithms for Quantum-Many Body Systems in two and higher dimensions},
+    author = {F. Verstraete and J. I. Cirac},
+    journal = {arxiv:0407066},
+    url = {https://arxiv.org/abs/cond-mat/0407066},
+    year = {2004}
+}
 
 @article{Verstraete:2004r,
   title = {Valence-bond states for quantum computation},


### PR DESCRIPTION
It seems that the eprint key or the fact that URL was written in all caps was leading to problems in link creation. I was lead here "https://arxiv.org/abs/%3Cspan%3Econd%E2%80%91mat/%5B0407066%5D(https://arxiv.org/abs/cond-mat/0407066)%3C/span%3E", rather than the actual link. I copied the arxiv bibtex entry from the mpo page and filled out the fields with the appropriate information of this reference.